### PR TITLE
add arguments for custom layout and style file

### DIFF
--- a/wkeys/src/config.rs
+++ b/wkeys/src/config.rs
@@ -1,20 +1,32 @@
 use std::fs;
 
-use crate::{layout::assets::LayoutAssets, ui::StyleAssets};
+use crate::{info, layout::assets::LayoutAssets, ui::StyleAssets};
 
 pub struct AppConfig {
     xdg_dirs: xdg::BaseDirectories,
+    custom_layout_path: Option<String>,
+    custom_style_path: Option<String>,
 }
 
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
             xdg_dirs: xdg::BaseDirectories::with_prefix("wkeys").unwrap(),
+            custom_layout_path: None,
+            custom_style_path: None,
         }
     }
 }
 
 impl AppConfig {
+    pub fn new(custom_layout_path: Option<String>, custom_style_path: Option<String>) -> Self {
+        Self {
+            xdg_dirs: xdg::BaseDirectories::with_prefix("wkeys").unwrap(),
+            custom_layout_path,
+            custom_style_path,
+        }
+    }
+
     fn get_config_file_content(&self, file_name: &str, fallback: &str) -> String {
         match self.xdg_dirs.find_config_file(file_name) {
             Some(css_path) => return fs::read_to_string(css_path).unwrap(),
@@ -24,11 +36,27 @@ impl AppConfig {
         }
     }
 
+    fn get_custom_file_content(&self, file_path: &str) -> Result<String, std::io::Error> {
+        fs::read_to_string(file_path)
+    }
+
     pub fn get_css_file_content(&self) -> String {
+        if let Some(path) = &self.custom_style_path {
+            match self.get_custom_file_content(path) {
+                Ok(content) => return content,
+                Err(e) => info!("Error reading custom style file: {}", e)
+            }
+        }
         self.get_config_file_content("style.css", &StyleAssets::get_default_style_file())
     }
 
     pub fn get_layout_file_content(&self) -> String {
+        if let Some(path) = &self.custom_layout_path {
+            match self.get_custom_file_content(path) {
+                Ok(content) => return content,
+                Err(e) => info!("Error reading custom layout file: {}", e)
+            }
+        }
         self.get_config_file_content(
             "layout.toml",
             &&LayoutAssets::get_get_default_60_percent_layout_str(),

--- a/wkeys/src/main.rs
+++ b/wkeys/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         })
         .unwrap();
 
-        let app_config = AppConfig::default();
+        let app_config = AppConfig::new(args.layout.clone(), args.style.clone());
         let user_layout = LayoutDefinition::from_toml(&app_config.get_layout_file_content());
         let user_style = app_config.get_css_file_content();
 

--- a/wkeys/src/service/host.rs
+++ b/wkeys/src/service/host.rs
@@ -49,7 +49,7 @@ impl<M: KeyboardHandle + 'static, N: IPCHandle + Send + 'static> AppService<M, N
 
     pub fn run(self) {
         info!("Starting UI.");
-        self.ui_handle.run::<UIModel>((
+        self.ui_handle.with_args(vec![]).run::<UIModel>((
             Box::new(self.keyboard_handle),
             Box::new(self.ipc_handle),
             self.layout_definition,

--- a/wkeys/src/utils.rs
+++ b/wkeys/src/utils.rs
@@ -10,4 +10,10 @@ pub enum MessageEnum {
 pub struct ProgramArgs {
     #[arg(short, long)]
     pub message: Option<MessageEnum>,
+
+    #[arg(short, long, help = "Path to a custom layout file (.toml)")]
+    pub layout: Option<String>,
+
+    #[arg(short, long, help = "Path to a custom style file (.css)")]
+    pub style: Option<String>,
 }


### PR DESCRIPTION
hey.
i'm completely new to rust, so this is the result of prompting and research ;)

With this changes it is possible to use the following new arguments:

```
Usage: wkeys [OPTIONS]

Options:
  -l, --layout <LAYOUT>    Path to a custom layout file (.toml)
  -s, --style <STYLE>      Path to a custom style file (.css)
```

and it fixes the "unknown option" message while using `-m` `--message`.

.FIXES #4 