### PR TITLE
set gtk-layer-shell namespace to wkeys

### DIFF
--- a/wkeys/src/ui/main_view.rs
+++ b/wkeys/src/ui/main_view.rs
@@ -91,6 +91,7 @@ impl SimpleComponent for UIModel {
         window.set_height_request(window_height);
 
         window.init_layer_shell();
+        window.set_namespace(Some("wkeys"));
         window.set_layer(Layer::Overlay);
         window.set_keyboard_mode(KeyboardMode::None);
 


### PR DESCRIPTION
this fixes the unset gtk-layer-shell namespace, e.g. necessary for hyprland layerrules.

.FIXES #6