### PR TITLE
added support for stylues by using GestureStylus

### DIFF
--- a/wkeys/src/ui/components/button_ex.rs
+++ b/wkeys/src/ui/components/button_ex.rs
@@ -59,6 +59,22 @@ impl ObjectImpl for ButtonInner {
         });
 
         obj.add_controller(gesture);
+
+        let stylus = gtk::GestureStylus::new();
+
+        let obj_up_cb = obj.clone();
+        stylus.connect_up(move |stylus, _, _| {
+            stylus.set_state(gtk::EventSequenceState::Claimed);
+            obj_up_cb.emit_by_name::<()>("released", &[]);
+        });
+        
+        let obj_down_cb = obj.clone();
+        stylus.connect_down(move |stylus, _, _| {
+            stylus.set_state(gtk::EventSequenceState::Claimed);
+            obj_down_cb.emit_by_name::<()>("pressed", &[]);
+        });
+
+        obj.add_controller(stylus);
     }
 
     fn signals() -> &'static [Signal] {


### PR DESCRIPTION
Hey, i don't know if u have the possibility to test this.
I have some trouble with my stylus under hyprland especially with gtk4 rust.
But this brings up the possibility to use the keyboard with pen, but i must press pens button instead of just tapping the screen. but this should not be related to the implementation.

.FIXES #3 